### PR TITLE
Sort results option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@ pub struct Opt {
 
     #[structopt(short = "m", long = "minimum")]
     pub minimum: Option<u64>,
+
+    #[structopt(short = "s", long = "sort")]
+    pub sort: bool,
 }
 
 type BoxResult<T> = Result<T, Box<dyn Error>>;
@@ -83,7 +86,7 @@ fn walk_dirs(input: Vec<PathBuf>) -> CHashMap<PathBuf, ()> {
     return paths;
 }
 
-fn cull_by_filesize(input: CHashMap<PathBuf, ()>, minimum: u64) -> CHashMap<PathBuf, ()> {
+fn cull_by_filesize(input: CHashMap<PathBuf, ()>, minimum: u64) -> CHashMap<PathBuf, u64> {
     let dupes = CHashMap::new();
     let file_hashes = CHashMap::new();
     input
@@ -93,8 +96,8 @@ fn cull_by_filesize(input: CHashMap<PathBuf, ()>, minimum: u64) -> CHashMap<Path
             if let Ok(bytes_count) = byte_count_file(PathBuf::from(&current_path)) {
                 if bytes_count >= minimum {
                     if let Some(path) = file_hashes.insert(bytes_count, current_path.clone()) {
-                        dupes.insert(current_path.clone(), ());
-                        dupes.insert(path.to_path_buf(), ());
+                        dupes.insert(current_path.clone(), bytes_count);
+                        dupes.insert(path.to_path_buf(), bytes_count);
                     }
                 }
             }
@@ -102,7 +105,7 @@ fn cull_by_filesize(input: CHashMap<PathBuf, ()>, minimum: u64) -> CHashMap<Path
     return dupes;
 }
 
-fn cull_by_hash(input: CHashMap<PathBuf, ()>) -> Vec<(PathBuf, PathBuf)> {
+fn cull_by_hash(input: CHashMap<PathBuf, u64>) -> Vec<(PathBuf, PathBuf)> {
     let file_hashes = CHashMap::new();
     return input
         .into_iter()
@@ -118,50 +121,54 @@ fn cull_by_hash(input: CHashMap<PathBuf, ()>) -> Vec<(PathBuf, PathBuf)> {
         .collect::<Vec<(_, _)>>();
 }
 
-fn format_results(input: &Vec<(PathBuf, PathBuf)>) -> String {
+fn format_results(mut input: Vec<(PathBuf, PathBuf)>, paths: CHashMap<PathBuf, u64>) -> String {
+    input.sort_by_cached_key(|item| {
+        paths.get(&item.0);
+    });
     input
         .par_iter()
         .map(|item| {
             let (dupe1, dupe2) = item;
             format!(" {} | {} \n", dupe1.display(), dupe2.display())
         })
-        .reduce(String::new, |mut start, item| {
-            start.push_str(&item);
-            start
-        })
-}
-
-pub fn detect_dupes(options: Opt) -> usize {
-    let now = Instant::now();
-    let paths = walk_dirs(options.paths);
-    if options.debug {
-        println!("{} files found ", paths.len());
+    .reduce(String::new, |mut start, item| {
+        start.push_str(&item);
+        start
+    })
     }
 
-    let minimum = options.minimum.unwrap_or(0);
+    pub fn detect_dupes(options: Opt) -> usize {
+        let now = Instant::now();
+        let paths = walk_dirs(options.paths);
+        if options.debug {
+            println!("{} files found ", paths.len());
+        }
 
-    let paths = cull_by_filesize(paths, minimum);
+        let minimum = options.minimum.unwrap_or(0);
 
-    if options.debug {
-        println!("{} potential dupes after filesize cull", paths.len());
-    }
+        let paths = cull_by_filesize(paths, minimum);
 
-    let confirmed_dupes = cull_by_hash(paths);
+        if options.debug {
+            println!("{} potential dupes after filesize cull", paths.len());
+        }
 
-    if options.debug {
-        println!("{} dupes after full file hashing", confirmed_dupes.len());
-    }
+        let paths2 = paths.clone();
+        let confirmed_dupes = cull_by_hash(paths);
 
-    let output_string = format_results(&confirmed_dupes);
+        if options.debug {
+            println!("{} dupes after full file hashing", confirmed_dupes.len());
+        }
 
-    if let Some(path) = options.output {
-        let mut f = File::create(path).unwrap();
-        f.write_all(output_string.as_bytes()).unwrap();
-    } else {
-        println!("{}", output_string);
-    }
-    if options.timing {
-        print_timing_info(now);
-    }
-    return confirmed_dupes.len();
+        let output_string = format_results(confirmed_dupes.clone(), paths2);
+
+        if let Some(path) = options.output {
+            let mut f = File::create(path).unwrap();
+            f.write_all(output_string.as_bytes()).unwrap();
+        } else {
+            println!("{}", output_string);
+        }
+        if options.timing {
+            print_timing_info(now);
+        }
+        return confirmed_dupes.len();
 }


### PR DESCRIPTION
By specifying `-s` or `--sort` the results of dups can be sorted in `DESC` order.
The sorting is done by adding the size into the initial `paths: CHashMap` structure as a `u64` value.

NOTE: I would love to get rid of the `paths2` variable, but couldn't find a way since `cull_by_hash` is owning that value and it's moved there.